### PR TITLE
Add support for EL 7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for ansible-role-docker
+
+# Systemd drop-in paths (required on EL7)
+docker_dropin_dir: "/etc/systemd/system/docker.service.d"

--- a/files/docker.repo
+++ b/files/docker.repo
@@ -1,0 +1,6 @@
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
 # handlers file for docker.ubuntu
+- name: reload systemd
+  command: systemctl daemon-reload
+
 - name: start docker
   service: name=docker state=started
 
@@ -8,5 +11,3 @@
 
 - name: restart docker
   service: name=docker state=restarted
-
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,12 +5,13 @@ galaxy_info:
   license: Apache
   min_ansible_version: 2.0
   platforms:
-  - name: Ubuntu
-    versions:
-    - trusty
-  galaxy_tags: 
-   - docker
+    - name: Ubuntu
+      versions:
+        - trusty
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - docker
 
 dependencies: []
-
-

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,0 +1,30 @@
+---
+# Common setup tasks for all supported OS families
+
+- name: "[Common] Install base dependencies"
+  package:
+    name={{ item }}
+    state=present
+  with_items:
+    - "{{ python_dev_package }}"
+    - "{{ python_setuptools_package }}"
+
+- name: "[Common] Install pip"
+  easy_install:
+    name=pip
+    state=present
+
+# Required by the Ansible Docker module
+- name: "[Common] Install docker-py"
+  pip:
+    name=docker-py
+    state=present
+    version=1.2.3
+
+- name: "[Common] Install Docker Engine package"
+  package:
+    name=docker-engine
+    state=present
+
+- name: "[Common] Ensure docker-engine is enabled at boot time"
+  service: name=docker enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
     msg="This role is not supported on {{ansible_distribution}}"
   when: "ansible_distribution != 'Ubuntu' and ansible_os_family != 'RedHat'"
 
+- name: Include distribution-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "vars/{{ ansible_distribution|lower }}.yml"
+    - "vars/{{ ansible_os_family|lower }}.yml"
+
 # Include the relevant distro-specific task
 - name: Perform setup for Ubuntu
   include: ubuntu.yml
@@ -12,3 +18,5 @@
 - name: Perform setup for EL and derivatives
   include: redhat.yml
   when: ansible_os_family == 'RedHat'
+
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,52 +1,14 @@
-- name: Fail if OS distro is not Ubuntu 14.04
-  fail: 
-      msg="The role is designed only for Ubuntu 14.04"
-  when: "{{ ansible_distribution_version | version_compare('14.04', '!=') }}"
+---
+- name: Fail if the OS is not supported
+  fail:
+    msg="This role is not supported on {{ansible_distribution}}"
+  when: "ansible_distribution != 'Ubuntu' and ansible_os_family != 'RedHat'"
 
-- name: Install dependencies
-  apt: 
-      name={{ item }} 
-      update_cache=yes
-      state=present
-  with_items: 
-      - python-dev
-      - python-setuptools
+# Include the relevant distro-specific task
+- name: Perform setup for Ubuntu
+  include: ubuntu.yml
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Install pip
-  easy_install: 
-      name=pip 
-      state=present
-
-- name: Install docker-py
-  pip: 
-      name=docker-py 
-      state=present
-      version=1.2.3
-
-- name: Add docker apt repo
-  apt_repository:
-      repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
-      state=present
-
-- name: Import the Docker repository key
-  apt_key:
-      url=https://apt.dockerproject.org/gpg
-      state=present
-      id=2C52609D
-
-- name: Install Docker package
-  apt:
-      name=docker-engine
-      update_cache=yes
-      state=present
-
-- name: Configure docker0 bridge
-  lineinfile:
-    dest: /etc/default/docker
-    state: present
-    insertafter: ^DOCKER_OPTS=.*
-    line: "DOCKER_OPTS=\"$DOCKER_OPTS --bip={{docker_bridge_ip}}/24 \""
-  notify:
-    - restart docker
-
-- meta: flush_handlers
+- name: Perform setup for EL and derivatives
+  include: redhat.yml
+  when: ansible_os_family == 'RedHat'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,37 +1,14 @@
 ---
-- name: Fail if distro is not supported nor tested
+- name: "[EL] Fail if distro is not supported nor tested"
   fail: msg="The role is designed only for RedHat/CentOS 7.2 or later"
   when: "ansible_distribution not in ('RedHat', 'CentOS') or {{ ansible_distribution_version | version_compare('7.2', '<') }}"
 
-- name: Install base dependencies
-  yum:
-    name={{ item }}
-    update_cache=yes
-    state=present
-  with_items:
-    - python-devel
-    - python-setuptools
-
-- name: Install pip
-  easy_install:
-    name=pip
-    state=present
-
-- name: Install docker-py
-  pip:
-    name=docker-py
-    state=present
-    version=1.2.3
-
-- name: Add Docker yum repository
+- name: "[EL] Add Docker yum repository"
   copy:
     src=files/docker.repo dest=/etc/yum.repos.d/docker.repo mode=0644
 
-- name: Install Docker Engine package
-  yum:
-    name=docker-engine
-    update_cache=yes
-    state=present
+- name: "[EL] Perform common tasks"
+  include: common.yml
 
 # Setting up the docker0 bridge on Ubuntu 14.04 is done by literally changing
 # a single line in /etc/default/docker. Unfortunately on EL and derivatives
@@ -39,20 +16,15 @@
 # 1) create /etc/systemd/system/docker.service.d
 # 2) create custom.conf drop-in in said directory
 # 3) notify systemd it should reload all units and restart Docker
-- name: Create systemd drop-in directory for Docker
+- name: "[EL] Create systemd drop-in directory for Docker"
   file:
     path={{docker_dropin_dir}}
     state=directory
     mode=0755
 
-- name: Configure docker0 bridge
+- name: "[EL] Configure docker0 bridge"
   template:
     src=docker-dropin.conf.j2 dest={{docker_dropin_dir}}/custom.conf
   notify:
     - reload systemd
     - restart docker
-
-- name: Enable Docker on boot
-  service: name=docker enabled=yes
-
-- meta: flush_handlers

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,58 @@
+---
+- name: Fail if distro is not supported nor tested
+  fail: msg="The role is designed only for RedHat/CentOS 7.2 or later"
+  when: "ansible_distribution not in ('RedHat', 'CentOS') or {{ ansible_distribution_version | version_compare('7.2', '<') }}"
+
+- name: Install base dependencies
+  yum:
+    name={{ item }}
+    update_cache=yes
+    state=present
+  with_items:
+    - python-devel
+    - python-setuptools
+
+- name: Install pip
+  easy_install:
+    name=pip
+    state=present
+
+- name: Install docker-py
+  pip:
+    name=docker-py
+    state=present
+    version=1.2.3
+
+- name: Add Docker yum repository
+  copy:
+    src=files/docker.repo dest=/etc/yum.repos.d/docker.repo mode=0644
+
+- name: Install Docker Engine package
+  yum:
+    name=docker-engine
+    update_cache=yes
+    state=present
+
+# Setting up the docker0 bridge on Ubuntu 14.04 is done by literally changing
+# a single line in /etc/default/docker. Unfortunately on EL and derivatives
+# this means going through a systemd drop-in dance:
+# 1) create /etc/systemd/system/docker.service.d
+# 2) create custom.conf drop-in in said directory
+# 3) notify systemd it should reload all units and restart Docker
+- name: Create systemd drop-in directory for Docker
+  file:
+    path={{docker_dropin_dir}}
+    state=directory
+    mode=0755
+
+- name: Configure docker0 bridge
+  template:
+    src=docker-dropin.conf.j2 dest={{docker_dropin_dir}}/custom.conf
+  notify:
+    - reload systemd
+    - restart docker
+
+- name: Enable Docker on boot
+  service: name=docker enabled=yes
+
+- meta: flush_handlers

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,0 +1,52 @@
+- name: Fail if OS distro is not Ubuntu 14.04
+  fail: 
+      msg="The role is designed only for Ubuntu 14.04"
+  when: "{{ ansible_distribution_version | version_compare('14.04', '!=') }}"
+
+- name: Install dependencies
+  apt: 
+      name={{ item }} 
+      update_cache=yes
+      state=present
+  with_items: 
+      - python-dev
+      - python-setuptools
+
+- name: Install pip
+  easy_install: 
+      name=pip 
+      state=present
+
+- name: Install docker-py
+  pip: 
+      name=docker-py 
+      state=present
+      version=1.2.3
+
+- name: Add docker apt repo
+  apt_repository:
+      repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
+      state=present
+
+- name: Import the Docker repository key
+  apt_key:
+      url=https://apt.dockerproject.org/gpg
+      state=present
+      id=2C52609D
+
+- name: Install Docker package
+  apt:
+      name=docker-engine
+      update_cache=yes
+      state=present
+
+- name: Configure docker0 bridge
+  lineinfile:
+    dest: /etc/default/docker
+    state: present
+    insertafter: ^DOCKER_OPTS=.*
+    line: "DOCKER_OPTS=\"$DOCKER_OPTS --bip={{docker_bridge_ip}}/24 \""
+  notify:
+    - restart docker
+
+- meta: flush_handlers

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,46 +1,27 @@
-- name: Fail if OS distro is not Ubuntu 14.04
-  fail: 
-      msg="The role is designed only for Ubuntu 14.04"
+---
+- name: "[Ubuntu] Fail if release is not supported"
+  fail:
+    msg="The role is designed only for Ubuntu 14.04"
   when: "{{ ansible_distribution_version | version_compare('14.04', '!=') }}"
 
-- name: Install dependencies
-  apt: 
-      name={{ item }} 
-      update_cache=yes
-      state=present
-  with_items: 
-      - python-dev
-      - python-setuptools
-
-- name: Install pip
-  easy_install: 
-      name=pip 
-      state=present
-
-- name: Install docker-py
-  pip: 
-      name=docker-py 
-      state=present
-      version=1.2.3
-
-- name: Add docker apt repo
+- name: "[Ubuntu] Add docker apt repo"
   apt_repository:
-      repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
-      state=present
+    repo='deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main'
+    state=present
 
-- name: Import the Docker repository key
+- name: "[Ubuntu] Import the Docker repository key"
   apt_key:
-      url=https://apt.dockerproject.org/gpg
-      state=present
-      id=2C52609D
+    url=https://apt.dockerproject.org/gpg
+    state=present
+    id=2C52609D
 
-- name: Install Docker package
-  apt:
-      name=docker-engine
-      update_cache=yes
-      state=present
+- name: "[Ubuntu] Force an apt cache refresh"
+  apt: update_cache=yes
 
-- name: Configure docker0 bridge
+- name: "[Ubuntu] Perform common tasks"
+  include: common.yml
+
+- name: "[Ubuntu] Configure docker0 bridge"
   lineinfile:
     dest: /etc/default/docker
     state: present
@@ -48,5 +29,3 @@
     line: "DOCKER_OPTS=\"$DOCKER_OPTS --bip={{docker_bridge_ip}}/24 \""
   notify:
     - restart docker
-
-- meta: flush_handlers

--- a/templates/docker-dropin.conf.j2
+++ b/templates/docker-dropin.conf.j2
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// --bip={{docker_bridge_ip}}/24

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,4 @@
+---
+# Package names for EL and derivatives
+python_dev_package: python-devel
+python_setuptools_package: python-setuptools

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -1,0 +1,4 @@
+---
+# Package names for Ubuntu
+python_dev_package: python-dev
+python_setuptools_package: python-setuptools


### PR DESCRIPTION
This is a mostly straightforward port of the Ubuntu task to RedHat/CentOS 7.2 and a "wrapper" as main.yml which selects the task that should run depending on the OS family.

There is a fair amount of code duplication between distro-specific tasks, this can be addressed by further splitting the tasks into common tasks (using the `package` module and defining distro-specific variables) and distro-specific tasks.

Given that Ansible 2.1 hasn't been released yet and the minimum supported Ansible version declared on Galaxy is 2.0, I had to use the `copy` module to set up the Docker Engine repository instead of the `yum_repository` module.
