### PR TITLE
Refactor Docker systemd drop-in

### DIFF
--- a/files/docker-dropin.conf
+++ b/files/docker-dropin.conf
@@ -1,0 +1,17 @@
+#######################################
+### This file is managed by Ansible ###
+###    DO NOT MODIFY IT MANUALLY    ###
+#######################################
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// $OPTIONS \
+          $DOCKER_STORAGE_OPTIONS \
+          $DOCKER_NETWORK_OPTIONS \
+          $DOCKER_CLUSTER_OPTIONS \
+          $BLOCK_REGISTRY \
+          $INSECURE_REGISTRY
+

--- a/files/docker.repo
+++ b/files/docker.repo
@@ -1,3 +1,8 @@
+#######################################
+### This file is managed by Ansible ###
+###    DO NOT MODIFY IT MANUALLY    ###
+#######################################
+
 [dockerrepo]
 name=Docker Repository
 baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,21 +10,28 @@
 - name: "[EL] Perform common tasks"
   include: common.yml
 
-# Setting up the docker0 bridge on Ubuntu 14.04 is done by literally changing
-# a single line in /etc/default/docker. Unfortunately on EL and derivatives
-# this means going through a systemd drop-in dance:
-# 1) create /etc/systemd/system/docker.service.d
-# 2) create custom.conf drop-in in said directory
-# 3) notify systemd it should reload all units and restart Docker
+# Setup Docker Engine to take configuration options from environment files
+# like we do on Ubuntu. This is the default for the docker-engine package in
+# RHEL7 but *not* in the upstream package, so we have to override the provided
+# systemd unit.
+#
+# See https://docs.docker.com/engine/admin/systemd/#custom-docker-daemon-options
+# for more information.
 - name: "[EL] Create systemd drop-in directory for Docker"
   file:
     path={{docker_dropin_dir}}
     state=directory
     mode=0755
 
-- name: "[EL] Configure docker0 bridge"
-  template:
-    src=docker-dropin.conf.j2 dest={{docker_dropin_dir}}/custom.conf
+- name: "[EL] Override Docker Engine startup parameters"
+  copy:
+    src=files/docker-dropin.conf dest={{docker_dropin_dir}}/custom.conf
   notify:
     - reload systemd
+    - restart docker
+
+- name: "[EL] Configure docker0 bridge"
+  template:
+    src=docker-network.conf.j2 dest=/etc/sysconfig/docker-network
+  notify:
     - restart docker

--- a/templates/docker-dropin.conf.j2
+++ b/templates/docker-dropin.conf.j2
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --bip={{docker_bridge_ip}}/24

--- a/templates/docker-network.conf.j2
+++ b/templates/docker-network.conf.j2
@@ -1,0 +1,6 @@
+#######################################
+### This file is managed by Ansible ###
+###    DO NOT MODIFY IT MANUALLY    ###
+#######################################
+
+DOCKER_NETWORK_OPTIONS="--bip={{ docker_bridge_ip }}/24"


### PR DESCRIPTION
Add support for EL-style environment files in /etc/sysconfig so that other roles (mainly [indigo-dc.calico](https://github.com/indigo-dc/ansible-role-calico)) can optionally alter a subset of parameters for docker-engine.
