### PR TITLE
Update the systemd drop-in for Docker 1.12

### DIFF
--- a/files/docker-dropin.conf
+++ b/files/docker-dropin.conf
@@ -8,7 +8,7 @@ EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// $OPTIONS \
+ExecStart=/usr/bin/dockerd $OPTIONS \
           $DOCKER_STORAGE_OPTIONS \
           $DOCKER_NETWORK_OPTIONS \
           $DOCKER_CLUSTER_OPTIONS \


### PR DESCRIPTION
Docker 1.12 changed the way the Docker Daemon is started by systemd on EL7:
- socket-activation is no longer supported (hence, drop the `-H fd://` argument)
- the daemon has been split from the main docker executable and lives in `/usr/bin/dockerd`

This PR addresses both changes.
