### PR TITLE
Fix/issue 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ansible-galaxy install geerlingguy.pip
   
   # Workaround for https://github.com/geerlingguy/ansible-role-pip/issues/37
-  - apt update
+  - sudo apt update
 
 script:
   # Basic role syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ install:
 
   # Create ansible.cfg with correct roles_path
   - printf '[defaults]\nroles_path=../' >ansible.cfg
+  
+  # Download role dependencies
+  - ansible-galaxy install geerlingguy.pip
 
 script:
   # Basic role syntax check

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ install:
   
   # Download role dependencies
   - ansible-galaxy install geerlingguy.pip
+  
+  # Workaround for https://github.com/geerlingguy/ansible-role-pip/issues/37
+  - apt update
 
 script:
   # Basic role syntax check

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Role Variables
 - `docker_storage_driver` (optional): Storage driver to use
 - `docker_log_driver` (optional): Log driver to use. Default: 'json-file'
 - `docker_logs_opts` (optional): Log driver options. Default: { 'max-file': '3', 'max-size': '100m' }
+- `docker_pip_package` (optional): The name of the packge to install to get pip on the system. For older systems that don't have Python 3 available, you can set this to `python-pip`. Default: `python3-pip`
+
+Dependencies
+--------------
+- geerlingguy.pip
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for ansible-role-docker
+docker_pip_package: python3-pip
 docker_config: {}
 docker_options:
   bip:             "{{ docker_bridge_ip_cidr  |default(None) }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,10 @@ galaxy_info:
   galaxy_tags:
     - docker
 
-dependencies: []
+dependencies:
+  - role: geerlingguy.pip
+    vars:
+      pip_package: "{{ docker_pip_package }}"
+      pip_install_packages: 
+        - "{{ 'docker' if ansible_version.minor >= 6 else 'docker-py' }}"
+  

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,37 +1,6 @@
 ---
 # Common setup tasks for all supported OS families
 
-- name: "[Common] Install base dependencies"
-  package:
-    name={{ item }}
-    state=present
-  with_items:
-    - "{{ python_dev_package }}"
-    - "{{ python_setuptools_package }}"
-
-- name: "[Common] Install pip"
-  easy_install:
-    name=pip
-    state=present
-
-- name: "[Common] Set docker-py package to be installed"
-  set_fact:
-    docker_py_package: "docker-py"
-
-# https://github.com/ansible/ansible/issues/42162
-# https://github.com/dcos-labs/ansible-dcos/pull/20
-- name: "[Common] Set docker-py package to be installed"
-  set_fact:
-    docker_py_package: "docker"
-  when: ansible_version.minor >= 6
-
-# Required by the Ansible Docker module
-- name: "[Common] Install docker-py dependency"
-  pip:
-    name="{{docker_py_package}}"
-    state=latest
-  
-
 - name: "[Common] Install Docker CE package"
   package:
     name=docker-ce

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
   remote_user: root
+  vars:
+    docker_pip_package: python-pip
   roles:
     - ansible-role-docker


### PR DESCRIPTION
- pip installation is now managed through the dedicated role (dependency: geerlingguy.pip)
- Python2 is still supported setting the variable `docker_pip_package` to `python-pip`